### PR TITLE
Update gl_backend.c

### DIFF
--- a/ref/gl/gl_backend.c
+++ b/ref/gl/gl_backend.c
@@ -77,7 +77,7 @@ void GL_BackendEndFrame( void )
 	case 2:
 		Q_snprintf( r_speeds_msg, sizeof( r_speeds_msg ),
 			"Renderer: ^1Engine^7\n\n"
-			"visible leafs:\n%3i leafs\ncurrent leaf %3i\n"
+			"visible leafs:\n%3i leafs\ncurrent leaf %3li\n"
 			"ReciusiveWorldNode: %3lf secs\nDrawTextureChains %lf",
 			r_stats.c_world_leafs, curleaf - WORLDMODEL->leafs, r_stats.t_world_node, r_stats.t_world_draw );
 		break;


### PR DESCRIPTION
Fixes the waf build error:

task in 'ref_gl' failed with exit status 1: 
	{task 139875678916496: c gl_backend.c -> gl_backend.c.1.o,gl_backend.c.1.d}

error in some older gcc versions due to type mismatch.